### PR TITLE
Make the images use the entire width of a narrow screen

### DIFF
--- a/index.html
+++ b/index.html
@@ -47,8 +47,8 @@
                     <hr />
                     <a href="https://ileonte.dev/focus-builds/">Nightly Builds</a> <span style="color: #79919d;">- built every 4 hours from the main branch</span>
                 </div>
-                <div class="col-10 col-sm-8 col-lg-6">
-                    <img src="images/focus.png" class="d-block mx-lg-auto img-fluid shadow-lg" alt="Focus Editor Screenshot"
+                <div class="col-lg-6">
+                    <img src="images/focus.png" class="d-block mx-lg-auto img-fluid shadow-lg w-100" alt="Focus Editor Screenshot"
                         width="700" height="500" loading="lazy">
                 </div>
             </div>
@@ -56,9 +56,9 @@
         <div class="b-divider"></div>
         <div id="about" class="container-lg px-4 py-5">
             <div class="row flex-lg align-items-center g-5 py-5">
-                <div class="col-10 col-sm-8 col-lg-6">
+                <div class="col-lg-6">
                     <a href="images/focus1.gif">
-                        <img src="images/focus1.gif" class="d-block mx-lg-auto img-fluid shadow-lg"
+                        <img src="images/focus1.gif" class="d-block mx-lg-auto img-fluid shadow-lg w-100"
                         alt="Focus Editor Screenshot" width="700" height="500" loading="lazy">
                     </a>
                 </div>
@@ -126,8 +126,8 @@ run_command:            test.exe
 
         <div id="development" class="container-lg px-4 py-5">
             <div class="row flex-lg align-items-center g-5 py-5">
-                <div class="col-10 col-sm-8 col-lg-6">
-                    <img src="images/github.png" class="d-block mx-lg-auto img-fluid shadow-lg"
+                <div class="col-lg-6">
+                    <img src="images/github.png" class="d-block mx-lg-auto img-fluid shadow-lg w-100"
                         alt="Focus Editor Screenshot" width="700" height="500" loading="lazy">
                 </div>
                 <div class="col-lg-6">


### PR DESCRIPTION
Previously there was a larger margin on the right side of the images than on the left side when using a narrow screen such as a phone. This change makes the images take up the entire width of the display and thus makes the margin on both sides equal.